### PR TITLE
Fix for breaking the recorder component

### DIFF
--- a/components/binary_sensor/xiaomi.py
+++ b/components/binary_sensor/xiaomi.py
@@ -103,9 +103,10 @@ class XiaomiMotionSensor(XiaomiDevice, BinarySensorDevice):
                 return False
             self._ghost_checked = False
             self._should_poll = True
-            self._hass.bus.fire('motion', {
-                'entity_id': self.entity_id
-            })
+            if self.entity_id != None:
+                self._hass.bus.fire('motion', {
+                    'entity_id': self.entity_id
+                })
 
             self._no_motion_since = 0
             if self._state:


### PR DESCRIPTION
Sometimes the xiaomi component fires an event where the `entity_id` is `None` resulting in the crash of the recorder component:

````
Exception in thread Recorder:
Traceback (most recent call last):
  File "/usr/lib/python3.4/threading.py", line 920, in _bootstrap_inner
    self.run()
  File "/home/hass/lib/python3.4/site-packages/homeassistant/components/recorder/__init__.py", line 250, in run
    domain = split_entity_id(entity_id)[0]
  File "/home/hass/lib/python3.4/site-packages/homeassistant/core.py", line 63, in split_entity_id
    return entity_id.split(".", 1)
AttributeError: 'NoneType' object has no attribute 'split'
````

This is an attempt for a fix